### PR TITLE
master: RRSet.Profile: convert from StringProfile to RawProfile

### DIFF
--- a/rrset.go
+++ b/rrset.go
@@ -14,16 +14,6 @@ type RRSetsService struct {
 
 // Here is the big 'Profile' mess that should get refactored to a more managable place
 
-// StringProfile wraps a Profile string
-type StringProfile struct {
-	Profile string `json:"profile,omitempty"`
-}
-
-// Metaprofile is a helper struct for extracting a Context from a StringProfile
-type Metaprofile struct {
-	Context ProfileSchema `json:"@context"`
-}
-
 // ProfileSchema are the schema URIs for RRSet Profiles
 type ProfileSchema string
 
@@ -37,6 +27,112 @@ const (
 	// TCPoolSchema is the schema URI for a Traffic Controller pool profile
 	TCPoolSchema = "http://schemas.ultradns.com/TCPool.jsonschema"
 )
+
+// RawProfile represents the naive interface to an RRSet Profile
+type RawProfile map[string]interface{}
+
+// Context extracts the schema context from a RawProfile
+func (rp RawProfile) Context() ProfileSchema {
+	return ProfileSchema(rp["@context"].(string))
+}
+
+// GetProfileObject extracts the full Profile by its schema type
+func (rp RawProfile) GetProfileObject() (interface{}, error) {
+	c := rp.Context()
+	switch c {
+	case DirPoolSchema:
+		return rp.DirPoolProfile()
+	case RDPoolSchema:
+		return rp.RDPoolProfile()
+	case SBPoolSchema:
+		return rp.SBPoolProfile()
+	case TCPoolSchema:
+		return rp.TCPoolProfile()
+	default:
+		return nil, fmt.Errorf("Fallthrough on GetProfileObject type %s\n", c)
+	}
+}
+
+// remarshalJSON takes a structure and marshals it into another type
+func remarshalJSON(in, result interface{}) error {
+	bs, err := json.Marshal(in)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(bs, &result)
+}
+
+// DirPoolProfile extracts the full Profile as a DirPoolProfile or returns an error
+func (rp RawProfile) DirPoolProfile() (DirPoolProfile, error) {
+	var result DirPoolProfile
+	c := rp.Context()
+	if c != DirPoolSchema {
+		return result, fmt.Errorf("RDPoolProfile has incorrect JSON-LD @context %s\n", c)
+	}
+	err := remarshalJSON(rp, &result)
+	return result, err
+}
+
+// RDPoolProfile extracts the full Profile as a RDPoolProfile or returns an error
+func (rp RawProfile) RDPoolProfile() (RDPoolProfile, error) {
+	var result RDPoolProfile
+	c := rp.Context()
+	if c != RDPoolSchema {
+		return result, fmt.Errorf("RDPoolProfile has incorrect JSON-LD @context %s\n", c)
+	}
+	err := remarshalJSON(rp, &result)
+	return result, err
+}
+
+// SBPoolProfile extracts the full Profile as a SBPoolProfile or returns an error
+func (rp RawProfile) SBPoolProfile() (SBPoolProfile, error) {
+	var result SBPoolProfile
+	c := rp.Context()
+	if c != SBPoolSchema {
+		return result, fmt.Errorf("SBPoolProfile has incorrect JSON-LD @context %s\n", c)
+	}
+	err := remarshalJSON(rp, &result)
+	return result, err
+}
+
+// TCPoolProfile extracts the full Profile as a TCPoolProfile or returns an error
+func (rp RawProfile) TCPoolProfile() (TCPoolProfile, error) {
+	var result TCPoolProfile
+	c := rp.Context()
+	if c != TCPoolSchema {
+		return result, fmt.Errorf("TCPoolProfile has incorrect JSON-LD @context %s\n", c)
+	}
+	err := remarshalJSON(rp, &result)
+	return result, err
+}
+
+// RawProfile converts to a naive RawProfile
+func (p DirPoolProfile) RawProfile() (RawProfile, error) {
+	var rp RawProfile
+	err := remarshalJSON(p, &rp)
+	return rp, err
+}
+
+// RawProfile converts to a naive RawProfile
+func (p RDPoolProfile) RawProfile() (RawProfile, error) {
+	var rp RawProfile
+	err := remarshalJSON(p, &rp)
+	return rp, err
+}
+
+// RawProfile converts to a naive RawProfile
+func (p SBPoolProfile) RawProfile() (RawProfile, error) {
+	var rp RawProfile
+	err := remarshalJSON(p, &rp)
+	return rp, err
+}
+
+// RawProfile converts to a naive RawProfile
+func (p TCPoolProfile) RawProfile() (RawProfile, error) {
+	var rp RawProfile
+	err := remarshalJSON(p, &rp)
+	return rp, err
+}
 
 // DirPoolProfile wraps a Profile for a Directional Pool
 type DirPoolProfile struct {
@@ -115,102 +211,13 @@ type TCPoolProfile struct {
 	BackupRecord *BackupRecord `json:"backupRecord,omitempty"`
 }
 
-// UnmarshalJSON does what it says on the tin
-func (sp *StringProfile) UnmarshalJSON(b []byte) (err error) {
-	sp.Profile = string(b)
-	return nil
-}
-
-// MarshalJSON does what it says on the tin
-func (sp *StringProfile) MarshalJSON() ([]byte, error) {
-	if sp.Profile != "" {
-		return []byte(sp.Profile), nil
-	}
-	return json.Marshal(nil)
-}
-
-// Metaprofile converts a StringProfile to a Metaprofile to extract the context
-func (sp *StringProfile) Metaprofile() (Metaprofile, error) {
-	var mp Metaprofile
-	if sp.Profile == "" {
-		return mp, fmt.Errorf("Empty Profile cannot be converted to a Metaprofile")
-	}
-	err := json.Unmarshal([]byte(sp.Profile), &mp)
-	if err != nil {
-		return mp, fmt.Errorf("Error getting profile type: %+v\n", err)
-	}
-	return mp, nil
-}
-
-// Context extracts the schema context from a StringProfile
-func (sp *StringProfile) Context() ProfileSchema {
-	mp, err := sp.Metaprofile()
-	if err != nil {
-		log.Printf("[ERROR] %+s\n", err)
-		return ""
-	}
-	return mp.Context
-}
-
-// GoString returns the StringProfile's Profile.
-func (sp *StringProfile) GoString() string {
-	return sp.Profile
-}
-
-// String returns the StringProfile's Profile.
-func (sp *StringProfile) String() string {
-	return sp.Profile
-}
-
-// GetProfileObject extracts the full Profile by its schema type
-func (sp *StringProfile) GetProfileObject() interface{} {
-	c := sp.Context()
-	switch c {
-	case DirPoolSchema:
-		var dpp DirPoolProfile
-		err := json.Unmarshal([]byte(sp.Profile), &dpp)
-		if err != nil {
-			log.Printf("Could not Unmarshal the DirPoolProfile.\n")
-			return nil
-		}
-		return dpp
-	case RDPoolSchema:
-		var rdp RDPoolProfile
-		err := json.Unmarshal([]byte(sp.Profile), &rdp)
-		if err != nil {
-			log.Printf("Could not Unmarshal the RDPoolProfile.\n")
-			return nil
-		}
-		return rdp
-	case SBPoolSchema:
-		var sbp SBPoolProfile
-		err := json.Unmarshal([]byte(sp.Profile), &sbp)
-		if err != nil {
-			log.Printf("Could not Unmarshal the SBPoolProfile.\n")
-			return nil
-		}
-		return sbp
-	case TCPoolSchema:
-		var tcp TCPoolProfile
-		err := json.Unmarshal([]byte(sp.Profile), &tcp)
-		if err != nil {
-			log.Printf("Could not Unmarshal the TCPoolProfile.\n")
-			return nil
-		}
-		return tcp
-	default:
-		log.Printf("ERROR - Fall through on GetProfileObject - %s.\n", c)
-		return fmt.Errorf("Fallthrough on GetProfileObject type %s\n", c)
-	}
-}
-
 // RRSet wraps an RRSet resource
 type RRSet struct {
-	OwnerName string         `json:"ownerName"`
-	RRType    string         `json:"rrtype"`
-	TTL       int            `json:"ttl"`
-	RData     []string       `json:"rdata"`
-	Profile   *StringProfile `json:"profile,omitempty"`
+	OwnerName string     `json:"ownerName"`
+	RRType    string     `json:"rrtype"`
+	TTL       int        `json:"ttl"`
+	RData     []string   `json:"rdata"`
+	Profile   RawProfile `json:"profile,omitempty"`
 }
 
 // RRSetListDTO wraps a list of RRSet resources

--- a/rrset_test.go
+++ b/rrset_test.go
@@ -72,7 +72,8 @@ func Test_RRSets_Select(t *testing.T) {
 			t.Logf("Found Profile %s for %s\n", rr.Profile.Context(), rr.OwnerName)
 			st, er := json.Marshal(rr.Profile)
 			t.Logf("Marshal the profile to JSON: %s / %+v", string(st), er)
-			t.Logf("Check the Magic Profile: %+v\n", rr.Profile.GetProfileObject())
+			p, _ := rr.Profile.GetProfileObject()
+			t.Logf("Check the Magic Profile: %+v\n", p)
 		}
 	}
 }
@@ -103,8 +104,17 @@ func Test_RRSets_Create(t *testing.T) {
 		RRType:    r.Type,
 		TTL:       300,
 		RData:     []string{testIP1},
-		Profile:   &StringProfile{Profile: testProfile},
 	}
+	p := RDPoolProfile{
+		Context:     RDPoolSchema,
+		Order:       "ROUND_ROBIN",
+		Description: "T. migratorius",
+	}
+	rp, err := p.RawProfile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	val.Profile = rp
 	t.Logf("Create(%v, %v)", r, val)
 	resp, err := testClient.RRSets.Create(r, val)
 
@@ -174,8 +184,17 @@ func Test_RRSets_Update(t *testing.T) {
 		RRType:    r.Type,
 		TTL:       300,
 		RData:     []string{testIP2},
-		Profile:   &StringProfile{Profile: testProfile2},
 	}
+	p := RDPoolProfile{
+		Context:     RDPoolSchema,
+		Order:       "RANDOM",
+		Description: "T. migratorius",
+	}
+	rp, err := p.RawProfile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	val.Profile = rp
 	t.Logf("Update(%v, %v)", r, val)
 	resp, err := testClient.RRSets.Update(r, val)
 
@@ -215,7 +234,8 @@ func Test_RRSets_SelectMid(t *testing.T) {
 	if rrsets[0].RData[0] != testIP2 {
 		t.Fatalf("RData[0]\"%s\" != testIP2\"%s\"", rrsets[0].RData[0], testIP2)
 	}
-	t.Logf("Profile Check: %+v", rrsets[0].Profile.GetProfileObject())
+	p, _ := rrsets[0].Profile.GetProfileObject()
+	t.Logf("Check the Magic Profile: %+v\n", p)
 }
 
 func Test_RRSet_Delete(t *testing.T) {


### PR DESCRIPTION
Using StringProfile required keeping the raw profile around as an
JSON string blob. This added an unnecessary level of indirection, and
conversions for most usual access to profile data.

RawProfile instead acts as shorthand for a slightly less naive
map[string]interfac{}, and provides conversion functions to ease access
to concrete profile data types.

Unfortunately, conversions between these types are being handled by
remarshalJSON(), which roundtrips though JSON serialization in order to
convert between the generic RawProfile and concrete profile type. This
probably should be converted to a pure reflect implementation at some
point.
