### PR TITLE
add mapstructure tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+* Add terraform tags to structs to support mapstructure
+
 ### Fixed
 * `omitempty` tags fixed for `DirPoolProfile.NoResponse`, `DPRDataInfo.GeoInfo`, `DPRDataInfo.IPInfo`, `IPInfo.Ips` & `GeoInfo.Codes`
 * ProbeAlertDataDTO equivalence for times with different locations

--- a/directional_pool.go
+++ b/directional_pool.go
@@ -28,10 +28,10 @@ type AccountLevelGeoDirectionalGroupDTO struct {
 
 // IPAddrDTO wraps an IP address range or CIDR block
 type IPAddrDTO struct {
-	Start   string `json:"start,omitempty"`
-	End     string `json:"end,omitempty"`
-	CIDR    string `json:"cidr,omitempty"`
-	Address string `json:"address,omitempty"`
+	Start   string `json:"start,omitempty" terraform:"start"`
+	End     string `json:"end,omitempty" terraform:"end"`
+	CIDR    string `json:"cidr,omitempty" terraform:"cidr"`
+	Address string `json:"address,omitempty" terraform:"address"`
 }
 
 // AccountLevelIPDirectionalGroupDTO wraps an account-level, IP directional-group response

--- a/rrset.go
+++ b/rrset.go
@@ -157,23 +157,23 @@ type DirPoolProfile struct {
 
 // DPRDataInfo wraps the rdataInfo object of a DirPoolProfile response
 type DPRDataInfo struct {
-	AllNonConfigured bool     `json:"allNonConfigured,omitempty"`
-	IPInfo           *IPInfo  `json:"ipInfo,omitempty"`
-	GeoInfo          *GeoInfo `json:"geoInfo,omitempty"`
+	AllNonConfigured bool     `json:"allNonConfigured,omitempty" terraform:"all_non_configured"`
+	IPInfo           *IPInfo  `json:"ipInfo,omitempty" terraform:"ip_info"`
+	GeoInfo          *GeoInfo `json:"geoInfo,omitempty" terraform:"geo_info"`
 }
 
 // IPInfo wraps the ipInfo object of a DPRDataInfo
 type IPInfo struct {
-	Name           string      `json:"name"`
-	IsAccountLevel bool        `json:"isAccountLevel,omitempty"`
-	Ips            []IPAddrDTO `json:"ips,omitempty"`
+	Name           string      `json:"name" terraform:"name"`
+	IsAccountLevel bool        `json:"isAccountLevel,omitempty" terraform:"is_account_level"`
+	Ips            []IPAddrDTO `json:"ips,omitempty" terraform:"-"`
 }
 
 // GeoInfo wraps the geoInfo object of a DPRDataInfo
 type GeoInfo struct {
-	Name           string   `json:"name"`
-	IsAccountLevel bool     `json:"isAccountLevel,omitempty"`
-	Codes          []string `json:"codes,omitempty"`
+	Name           string   `json:"name" terraform:"name"`
+	IsAccountLevel bool     `json:"isAccountLevel,omitempty" terraform:"is_account_level"`
+	Codes          []string `json:"codes,omitempty" terraform:"codes"`
 }
 
 // RDPoolProfile wraps a Profile for a Resource Distribution pool


### PR DESCRIPTION
I didn't like this with a `mapstructure` tag, so I've used a `terraform` tag to describe its main user. It simplifies the code in the terraform provider.
