### PR TITLE
TOP-942 - add availableToServe to SBPool and TCPool DTOs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.3.3] - 2017-12-19
+### Changed
+- Added 'availableToServe' to SBPool and TCPool profile DTOs.
+
 ## [1.3.2] - 2017-03-03
 ### Changed
 - CheckResponse: improve fallthrough error to include full Response Status and properly format Body

--- a/rrset.go
+++ b/rrset.go
@@ -196,7 +196,7 @@ type SBPoolProfile struct {
 	MaxServed        int            `json:"maxServed,omitempty"`
 	RDataInfo        []SBRDataInfo  `json:"rdataInfo"`
 	BackupRecords    []BackupRecord `json:"backupRecords"`
-	AvailableToServe bool           `json:"availableToServe,-"`
+	AvailableToServe bool           `json:"availableToServe,omitempty"`
 }
 
 // SBRDataInfo wraps the rdataInfo object of a SBPoolProfile
@@ -224,7 +224,7 @@ type TCPoolProfile struct {
 	MaxToLB          int           `json:"maxToLB,omitempty"`
 	RDataInfo        []SBRDataInfo `json:"rdataInfo"`
 	BackupRecord     *BackupRecord `json:"backupRecord,omitempty"`
-	AvailableToServe bool          `json:"availableToServe,-"`
+	AvailableToServe bool          `json:"availableToServe,omitempty"`
 }
 
 // RRSet wraps an RRSet resource

--- a/rrset.go
+++ b/rrset.go
@@ -187,15 +187,16 @@ type RDPoolProfile struct {
 
 // SBPoolProfile wraps a Profile for a SiteBacker pool
 type SBPoolProfile struct {
-	Context       ProfileSchema  `json:"@context"`
-	Description   string         `json:"description"`
-	RunProbes     bool           `json:"runProbes"`
-	ActOnProbes   bool           `json:"actOnProbes"`
-	Order         string         `json:"order,omitempty"`
-	MaxActive     int            `json:"maxActive,omitempty"`
-	MaxServed     int            `json:"maxServed,omitempty"`
-	RDataInfo     []SBRDataInfo  `json:"rdataInfo"`
-	BackupRecords []BackupRecord `json:"backupRecords"`
+	Context          ProfileSchema  `json:"@context"`
+	Description      string         `json:"description"`
+	RunProbes        bool           `json:"runProbes"`
+	ActOnProbes      bool           `json:"actOnProbes"`
+	Order            string         `json:"order,omitempty"`
+	MaxActive        int            `json:"maxActive,omitempty"`
+	MaxServed        int            `json:"maxServed,omitempty"`
+	RDataInfo        []SBRDataInfo  `json:"rdataInfo"`
+	BackupRecords    []BackupRecord `json:"backupRecords"`
+	AvailableToServe bool           `json:"availableToServe,-"`
 }
 
 // SBRDataInfo wraps the rdataInfo object of a SBPoolProfile
@@ -216,13 +217,14 @@ type BackupRecord struct {
 
 // TCPoolProfile wraps a Profile for a Traffic Controller pool
 type TCPoolProfile struct {
-	Context      ProfileSchema `json:"@context"`
-	Description  string        `json:"description"`
-	RunProbes    bool          `json:"runProbes"`
-	ActOnProbes  bool          `json:"actOnProbes"`
-	MaxToLB      int           `json:"maxToLB,omitempty"`
-	RDataInfo    []SBRDataInfo `json:"rdataInfo"`
-	BackupRecord *BackupRecord `json:"backupRecord,omitempty"`
+	Context          ProfileSchema `json:"@context"`
+	Description      string        `json:"description"`
+	RunProbes        bool          `json:"runProbes"`
+	ActOnProbes      bool          `json:"actOnProbes"`
+	MaxToLB          int           `json:"maxToLB,omitempty"`
+	RDataInfo        []SBRDataInfo `json:"rdataInfo"`
+	BackupRecord     *BackupRecord `json:"backupRecord,omitempty"`
+	AvailableToServe bool          `json:"availableToServe,-"`
 }
 
 // RRSet wraps an RRSet resource


### PR DESCRIPTION
So I'm not entirely certain this is correct.  I'm assuming the '-' will cause it to only omit on Marshal and not ignore on Unmarshal.

Blah blah blah impetus for change - UltraDNS changed their API recently and this breaks.
2017-11-14 Added the new parameter "availableToServe" to RDataInfo Fields which will apply to
SiteBacker and Traffic Controller pools.

Causing - * 'rdataInfo[0]' has invalid keys: availableToServe

